### PR TITLE
corrected README.md on CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ App.ApplicationAdapter = DS.LSAdapter.extend({
 If you are using Ember Localstorage Adapter within an Ember CLI project you can install it as an addon with the following command:
 
 ```sh
-npm install --save-dev ember-localstorage-adapter
+ember install:bower ember-localstorage-adapter
 ```
 
 Then in Brocfile.js import it before module.exports:


### PR DESCRIPTION
```sh
$ npm install --save-dev ember-localstorage-adapter
ember-localstorage-adapter@0.5.2 node_modules/ember-localstorage-adapter

$ ember server
version: 0.2.0-beta.1
Could not find watchman, falling back to NodeWatcher for file system events
Livereload server on port 35729
Serving on http://0.0.0.0:4200/
Path or pattern "node_modules/ember-localstorage-adapter/localstorage_adapter.js" did not match any files
Error: Path or pattern "node_modules/ember-localstorage-adapter/localstorage_adapter.js" did not match any files
(...)
```
