### PR TITLE
Handle localStorage being unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ App.store.adapter.on('QUOTA_EXCEEDED_ERR', function(records){
 App.store.commit();
 ```
 
+### Local Storage Unavailable
+
+When `localStorage` is not available (typically because the user has explicitly disabled it), the adapter will keep records in memory. When the adapter first discovers that this is the case, it will trigger a `persistenceUnavailable` event, which the application may use to take any necessary actions.
+
+```js
+adapter.on('persistenceUnavailable', function() {
+  // Maybe notify the user that their data won't live past the end of the current session
+});
+```
+
 Todo
 ----
 

--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -284,22 +284,27 @@
     getLocalStorage: function() {
       if (this._localStorage) { return this._localStorage; }
 
+      var storage;
       try {
-        this._localStorage = this.getNativeStorage();
+        storage = this.getNativeStorage() || this._enableInMemoryStorage();
       } catch (e) {
-        this.trigger('persistenceUnavailable', e);
-        this._localStorage = {
-          storage: {},
-          getItem: function(name) {
-            return this.storage[name];
-          },
-          setItem: function(name, value) {
-            this.storage[name] = value;
-          }
-        };
+        storage = this._enableInMemoryStorage(e);
       }
 
-      return this._localStorage;
+      return this._localStorage = storage;
+    },
+
+    _enableInMemoryStorage: function(reason) {
+      this.trigger('persistenceUnavailable', reason);
+      return {
+        storage: {},
+        getItem: function(name) {
+          return this.storage[name];
+        },
+        setItem: function(name, value) {
+          this.storage[name] = value;
+        }
+      };
     },
 
     // This exists primarily as a testing extension point

--- a/localstorage_adapter.js
+++ b/localstorage_adapter.js
@@ -268,7 +268,7 @@
     },
 
     loadData: function () {
-      var storage = localStorage.getItem(this.adapterNamespace());
+      var storage = this.getLocalStorage().getItem(this.adapterNamespace());
       return storage ? JSON.parse(storage) : {};
     },
 
@@ -278,7 +278,33 @@
 
       localStorageData[modelNamespace] = data;
 
-      localStorage.setItem(this.adapterNamespace(), JSON.stringify(localStorageData));
+      this.getLocalStorage().setItem(this.adapterNamespace(), JSON.stringify(localStorageData));
+    },
+
+    getLocalStorage: function() {
+      if (this._localStorage) { return this._localStorage; }
+
+      try {
+        this._localStorage = this.getNativeStorage();
+      } catch (e) {
+        this.trigger('persistenceUnavailable', e);
+        this._localStorage = {
+          storage: {},
+          getItem: function(name) {
+            return this.storage[name];
+          },
+          setItem: function(name, value) {
+            this.storage[name] = value;
+          }
+        };
+      }
+
+      return this._localStorage;
+    },
+
+    // This exists primarily as a testing extension point
+    getNativeStorage: function() {
+      return localStorage;
     },
 
     _namespaceForType: function (type) {


### PR DESCRIPTION
Discussion in #97. When `localStorage` is unavailable, triggers an event on the adapter and keeps records in memory instead.